### PR TITLE
Make the 5gc repo deployable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ export 5GC_ROOT_DIR ?= $(ROOT_DIR)
 
 export HOSTS_INI_FILE ?= $(5GC_ROOT_DIR)/hosts.ini
 
-# export EXTRA_VARS ?= "@$(5GC_ROOT_DIR)/vars/main.yml"
+export EXTRA_VARS ?= "@$(5GC_ROOT_DIR)/vars/main.yml"
 
 #### a. Debugging ####
 

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,0 +1,10 @@
+[ssh_connection]
+ssh_args = "-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o ControlMaster=auto -o ControlPersist=5m -o LogLevel=QUIET -o ForwardAgent=yes"
+control_path = /tmp/ansible-%%r@%%h:%%p
+
+[defaults]
+forks = 48
+pipelining = True
+host_key_checking = False
+deprecation_warnings=False
+hash_behaviour=merge

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,7 +1,7 @@
 core:
   standalone: "true"
   data_iface: ens18
-  values_file: "templates/core/sdcore-5g-values.yaml"
+  values_file: "roles/core/templates/sdcore-5g-values.yaml"
   ran_subnet: "172.20.0.0/16" # set it to empty to get subnet from 'data_iface'
   
   helm:


### PR DESCRIPTION
I was working with the onramp repo, but wanted to deploy and work with the 5G core only, but this repo was missing the `ansible.cfg` file and also needed to uncomment the `EXTRA_VARS` line.

Additionally, there was a typo on the `main.yaml` file that was not allowing the deployment of the helm chart, since it was not retrieving it from the correct place.

Note: From my tests, uncommenting the `EXTRA_VARS` line in this Makefile does not mess with the deployment when done via the OnRamp repo, as the `EXTRA_VARS` declared on the OnRamp Makefile takes precedence.