### PR TITLE
Make the AMF to use the IP address actually set in `vars/main.yml`

### DIFF
--- a/roles/core/templates/hpa-5g-values.yaml
+++ b/roles/core/templates/hpa-5g-values.yaml
@@ -57,7 +57,7 @@ omec-control-plane:
       deploy: true # if enabled then deploy sctp pod.
                     # Once backend is stable, this option will be enabled by default
       ngapp:
-        externalIp: {{ ansible_default_ipv4.address }}
+        externalIp: {{ core.amf.ip }}
         port: 38412
 
     upfadapter:

--- a/roles/core/templates/radio-5g-values.yaml
+++ b/roles/core/templates/radio-5g-values.yaml
@@ -60,7 +60,7 @@ omec-control-plane:
       # Use externalIP if you need to access AMF from remote setup
       # and you don't want setup NodePort Service Type
       ngapp:
-        externalIp: {{ ansible_default_ipv4.address }}
+        externalIp: {{ core.amf.ip }}
         port: 38412
       cfgFiles:
         amfcfg.conf:

--- a/roles/core/templates/sdcore-5g-values.yaml
+++ b/roles/core/templates/sdcore-5g-values.yaml
@@ -61,7 +61,7 @@ omec-control-plane:
       # Use externalIP if you need to access AMF from remote setup
       # and you don't want setup NodePort Service Type
       ngapp:
-        externalIp: {{ ansible_default_ipv4.address }}
+        externalIp: {{ core.amf.ip }}
         port: 38412
       cfgFiles:
         amfcfg.conf:


### PR DESCRIPTION
Currently, the AMF is configured with the main node's IP address, which is not correct and ignores the IP address set in the `vars/main.yml` file. This PR fixes this issue and set the AMF pod/service to actually expose the IP address configured/set in the `vars/main.yml` file