### PR TITLE
Update dependencies for 5g-control-plane Charts

### DIFF
--- a/roles/core/tasks/install.yml
+++ b/roles/core/tasks/install.yml
@@ -64,6 +64,11 @@
     var: "chart_ref_sd_core"
   when: inventory_hostname in groups['master_nodes'] and core.helm.local_charts
 
+- name: update aether 5gc-cp helm dependencies
+  shell: |
+    helm dep up /tmp/sdcore-helm-charts/5g-control-plane
+  when: inventory_hostname in groups['master_nodes'] and core.helm.local_charts
+
 - name: update aether 5gc helm dependencies
   shell: |
     helm dep up {{chart_ref_sd_core}}


### PR DESCRIPTION
When using local charts, it is required to run `helm dep up` for the `5g-control-plane` for the 5gc to properly work. If not, the establishment of the NGSetup will fail because mongodb does not exist.