### PR TITLE
Resolved issues in removing namespace for additional upf's

### DIFF
--- a/roles/upf/tasks/uninstall.yml
+++ b/roles/upf/tasks/uninstall.yml
@@ -20,7 +20,7 @@
 
 - name: delete namespace omec-upf
   shell: |
-    "kubectl delete namespace omec-upf-{{ item.key }}"
+    kubectl delete namespace omec-upf-{{ item.key }}
   with_dict: "{{ core.upf.additional_upfs}}"
   when: inventory_hostname in groups['master_nodes']
   ignore_errors: yes


### PR DESCRIPTION
The namespace for the additional UPF's not removed properly. So updating the shell command in the uninstall file to remove the namespace properly.