### PR TITLE
Disable upf adapter while stats support in adapter is missing

### DIFF
--- a/roles/core/templates/radio-5g-values.yaml
+++ b/roles/core/templates/radio-5g-values.yaml
@@ -60,7 +60,7 @@ omec-control-plane:
         port: 38412
 
     upfadapter:
-      deploy: true # If enabled then deploy upf adapter pod
+      deploy: false # If enabled then deploy upf adapter pod
 
     metricfunc:
       deploy: true

--- a/roles/core/templates/sdcore-5g-sriov-values.yaml
+++ b/roles/core/templates/sdcore-5g-sriov-values.yaml
@@ -60,7 +60,7 @@ omec-control-plane:
         port: 38412
 
     upfadapter:
-      deploy: true # If enabled then deploy upf adapter pod
+      deploy: false # If enabled then deploy upf adapter pod
 
     metricfunc:
       deploy: true

--- a/roles/core/templates/sdcore-5g-values.yaml
+++ b/roles/core/templates/sdcore-5g-values.yaml
@@ -60,7 +60,7 @@ omec-control-plane:
         port: 38412
 
     upfadapter:
-      deploy: true # If enabled then deploy upf adapter pod
+      deploy: false # If enabled then deploy upf adapter pod
 
     metricfunc:
       deploy: true


### PR DESCRIPTION
UPF adapter does not support Kafka streaming interface. Hence if in a setup upf adapter is enabled then statistics will not be available in KAFKA. We shall need to fix the upf adapter but to avoid seeing same issues in other setup we should disable UPF adapter in default onRamp deployment. 