### PR TITLE
This PR update SD-Core registries to be used and other minor changes

### DIFF
--- a/roles/core/templates/radio-5g-values.yaml
+++ b/roles/core/templates/radio-5g-values.yaml
@@ -16,7 +16,7 @@ omec-control-plane:
 5g-control-plane:
   enable5G: true
   images:
-    repository: ""    # defaults to Docker Hub
+    repository: "registry.aetherproject.org/proxy/"
     #tags:
     #  amf: <amf image tag>
     # refer to above Helm Chart to add other NF images
@@ -35,7 +35,9 @@ omec-control-plane:
     enabled: false
 
   config:
-    # logger:
+    logger:
+      Util:
+        debugLevel: warn
     #   # network function
     #   AMF:
     #     debugLevel: trace
@@ -106,7 +108,7 @@ omec-control-plane:
 omec-sub-provision:
   enable: true
   images:
-    repository: ""    # defaults to Docker Hub
+    repository: "registry.aetherproject.org/proxy/"
     #tags:
     #  simapp: #add simapp override image
 
@@ -117,7 +119,7 @@ omec-sub-provision:
           configuration:
             provision-network-slice: {{ core.standalone | string }} # if enabled, Device Groups & Slices configure by simapp
             sub-provision-endpt:
-              addr: webui.omec.svc.cluster.local  # subscriber configuation endpoint.
+              addr: webui  # subscriber configuation endpoint.
             # sub-proxy-endpt: # used if subscriber proxy is enabled in the ROC.
             #   addr: subscriber-proxy.aether-roc.svc.cluster.local
             #   port: 5000
@@ -199,7 +201,7 @@ omec-user-plane:
   resources:
     enabled: false
   images:
-    repository: ""    # defaults to Docker Hub
+    repository: "registry.aetherproject.org/proxy/"
     # following two lines pull busybox from Docker Hub instead of Aether Registry
     tags:
       tools: omecproject/busybox:stable
@@ -233,7 +235,7 @@ omec-user-plane:
         ip: {{ core_ip }}
       cfgFiles:
         upf.jsonc:
-          mode: af_packet                # This mode implies no DPDK
+          mode: {{ core.upf.mode }}
           hwcksum: true
           log_level: "info"
           measure_upf: true

--- a/roles/core/templates/sdcore-5g-sriov-values.yaml
+++ b/roles/core/templates/sdcore-5g-sriov-values.yaml
@@ -16,7 +16,7 @@ omec-control-plane:
 5g-control-plane:
   enable5G: true
   images:
-    repository: ""    # defaults to Docker Hub
+    repository: "registry.aetherproject.org/proxy/"
     #tags:
     #  amf: <amf image tag>
     # refer to above Helm Chart to add other NF images
@@ -35,7 +35,9 @@ omec-control-plane:
     enabled: false
 
   config:
-    # logger:
+    logger:
+      Util:
+        debugLevel: warn
     #   # network function
     #   AMF:
     #     debugLevel: trace
@@ -106,7 +108,7 @@ omec-control-plane:
 omec-sub-provision:
   enable: true
   images:
-    repository: ""    # defaults to Docker Hub
+    repository: "registry.aetherproject.org/proxy/"
     #tags:
     #  simapp: #add simapp override image
 
@@ -117,7 +119,7 @@ omec-sub-provision:
           configuration:
             provision-network-slice: {{ core.standalone | string }} # if enabled, Device Groups & Slices configure by simapp
             sub-provision-endpt:
-              addr: webui.omec.svc.cluster.local  # subscriber configuation endpoint.
+              addr: webui  # subscriber configuation endpoint.
             # sub-proxy-endpt: # used if subscriber proxy is enabled in the ROC.
             #   addr: subscriber-proxy.aether-roc.svc.cluster.local
             #   port: 5000
@@ -304,7 +306,7 @@ omec-user-plane:
   resources:
     enabled: true
   images:
-    repository: ""    # defaults to Docker Hub
+    repository: "registry.aetherproject.org/proxy/"
     # following two lines pull busybox from Docker Hub instead of Aether Registry
     tags:
       tools: omecproject/busybox:stable
@@ -341,7 +343,7 @@ omec-user-plane:
         ip: {{ core_ip }}
       cfgFiles:
         upf.jsonc:
-          mode: dpdk
+          mode: {{ core.upf.mode }}
           hwcksum: true
           log_level: "info"
           measure_upf: true

--- a/roles/core/templates/sdcore-5g-values.yaml
+++ b/roles/core/templates/sdcore-5g-values.yaml
@@ -16,7 +16,7 @@ omec-control-plane:
 5g-control-plane:
   enable5G: true
   images:
-    repository: ""    # defaults to Docker Hub
+    repository: "registry.aetherproject.org/proxy/"
     #tags:
     #  amf: <amf image tag>
     # refer to above Helm Chart to add other NF images
@@ -35,7 +35,9 @@ omec-control-plane:
     enabled: false
 
   config:
-    # logger:
+    logger:
+      Util:
+        debugLevel: warn
     #   # network function
     #   AMF:
     #     debugLevel: trace
@@ -106,7 +108,7 @@ omec-control-plane:
 omec-sub-provision:
   enable: true
   images:
-    repository: ""    # defaults to Docker Hub
+    repository: "registry.aetherproject.org/proxy/"
     #tags:
     #  simapp: #add simapp override image
 
@@ -304,7 +306,7 @@ omec-user-plane:
   resources:
     enabled: false
   images:
-    repository: ""    # defaults to Docker Hub
+    repository: "registry.aetherproject.org/proxy/"
     # following two lines pull busybox from Docker Hub instead of Aether Registry
     tags:
       tools: omecproject/busybox:stable
@@ -338,7 +340,7 @@ omec-user-plane:
         ip: {{ core_ip }}
       cfgFiles:
         upf.jsonc:
-          mode: af_packet                # This mode implies no DPDK
+          mode: {{ core.upf.mode }}
           hwcksum: true
           log_level: "info"
           measure_upf: true


### PR DESCRIPTION
This PR includes the following:
- Update the registries to be used for the deployment of the SD-Core
- Temporarily set the Util log level to `warn` until a proper fix is implemented in the `util/drsm` code (too many info logs come from the drsm module that clutter the logs
- Remove old reference to the `webui` (i.e., omec)
- Use `core.upf.mode` from the var/main.yml to setup the UPF's deployment mode

The changes here were tested using OnRamp

```
TASK [simulator : debug] ***********************************************************************************************
ok: [node1] => {
    "msg": [
        "Profile Name: profile2, Profile Type: pdusessest",
        "Ue's Passed: 5, Ue's Failed: 0",
        "Profile Status: PASS"
    ]
}

PLAY RECAP *************************************************************************************************************
node1                      : ok=12   changed=6    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
```

```
Events:
  Type     Reason          Age    From               Message
  ----     ------          ----   ----               -------
  Normal   Scheduled       2m23s  default-scheduler  Successfully assigned aether-5gc/amf-6f7cc496c4-ms2nz to node1
  Warning  FailedMount     2m22s  kubelet            MountVolume.SetUp failed for volume "certs" : failed to sync secret cache: timed out waiting for the condition
  Warning  FailedMount     2m22s  kubelet            MountVolume.SetUp failed for volume "nf-config" : failed to sync configmap cache: timed out waiting for the condition
  Normal   AddedInterface  2m17s  multus             Add eth0 [10.42.0.184/32]
  Normal   Pulling         2m14s  kubelet            Pulling image "registry.aetherproject.org/proxy/omecproject/pod-init:rel-1.1.1"
  Normal   Pulled          2m6s   kubelet            Successfully pulled image "registry.aetherproject.org/proxy/omecproject/pod-init:rel-1.1.1" in 8.136556605s
  Normal   Created         2m6s   kubelet            Created container wait-kafka-module
  Normal   Started         2m5s   kubelet            Started container wait-kafka-module
  Normal   Pulling         2m4s   kubelet            Pulling image "registry.aetherproject.org/proxy/omecproject/5gc-amf:rel-1.6.2"
  Normal   Pulled          117s   kubelet            Successfully pulled image "registry.aetherproject.org/proxy/omecproject/5gc-amf:rel-1.6.2" in 7.093817678s
  Normal   Created         117s   kubelet            Created container amf
  Normal   Started         117s   kubelet            Started container amf
```
