### PR TITLE
Add multihop support to deploy GNB's from multiple hops

### DIFF
--- a/roles/router/tasks/install.yml
+++ b/roles/router/tasks/install.yml
@@ -46,14 +46,14 @@
   template:
     src: roles/router/templates/systemd/10-aether-access.netdev
     dest: "{{ systemd_network_dir }}/10-aether-access.netdev"
-  when: inventory_hostname in groups['master_nodes'] and core.upf.multihop == false
+  when: inventory_hostname in groups['master_nodes'] and core.upf.non_isol_N3_nw == false
   become: true
 
 - name: copy 20-aether-access.network to {{ systemd_network_dir }}/20-aether-access.network
   template:
     src: roles/router/templates/systemd/20-aether-access.network
     dest: "{{ systemd_network_dir }}/20-aether-access.network"
-  when: inventory_hostname in groups['master_nodes'] and core.upf.multihop == false
+  when: inventory_hostname in groups['master_nodes'] and core.upf.non_isol_N3_nw == false
   become: true
 
 - name: copy 10-aether-core.netdev to {{ systemd_network_dir }}/10-aether-core.netdev
@@ -130,7 +130,7 @@
     in_interface: "{{ core.data_iface }}"
     out_interface: access
     jump: ACCEPT
-  when: inventory_hostname in groups['master_nodes'] and core.upf.multihop == false
+  when: inventory_hostname in groups['master_nodes'] and core.upf.non_isol_N3_nw == false
   become: true
 
 - name: "add iptable rule: forward from access to {{ core.data_iface }}"
@@ -139,7 +139,7 @@
     in_interface: access
     out_interface: "{{ core.data_iface }}"
     jump: ACCEPT
-  when: inventory_hostname in groups['master_nodes'] and core.upf.multihop == false
+  when: inventory_hostname in groups['master_nodes'] and core.upf.non_isol_N3_nw == false
   become: true
 
 - name: "add iptable rule: forward from {{ core.data_iface }} to core"

--- a/roles/router/tasks/install.yml
+++ b/roles/router/tasks/install.yml
@@ -46,14 +46,14 @@
   template:
     src: roles/router/templates/systemd/10-aether-access.netdev
     dest: "{{ systemd_network_dir }}/10-aether-access.netdev"
-  when: inventory_hostname in groups['master_nodes'] and core.upf.non_isol_N3_nw == false
+  when: inventory_hostname in groups['master_nodes'] and core.upf.multihop_gnb == false
   become: true
 
 - name: copy 20-aether-access.network to {{ systemd_network_dir }}/20-aether-access.network
   template:
     src: roles/router/templates/systemd/20-aether-access.network
     dest: "{{ systemd_network_dir }}/20-aether-access.network"
-  when: inventory_hostname in groups['master_nodes'] and core.upf.non_isol_N3_nw == false
+  when: inventory_hostname in groups['master_nodes'] and core.upf.multihop_gnb == false
   become: true
 
 - name: copy 10-aether-core.netdev to {{ systemd_network_dir }}/10-aether-core.netdev
@@ -130,7 +130,7 @@
     in_interface: "{{ core.data_iface }}"
     out_interface: access
     jump: ACCEPT
-  when: inventory_hostname in groups['master_nodes'] and core.upf.non_isol_N3_nw == false
+  when: inventory_hostname in groups['master_nodes'] and core.upf.multihop_gnb == false
   become: true
 
 - name: "add iptable rule: forward from access to {{ core.data_iface }}"
@@ -139,7 +139,7 @@
     in_interface: access
     out_interface: "{{ core.data_iface }}"
     jump: ACCEPT
-  when: inventory_hostname in groups['master_nodes'] and core.upf.non_isol_N3_nw == false
+  when: inventory_hostname in groups['master_nodes'] and core.upf.multihop_gnb == false
   become: true
 
 - name: "add iptable rule: forward from {{ core.data_iface }} to core"

--- a/roles/router/tasks/install.yml
+++ b/roles/router/tasks/install.yml
@@ -46,14 +46,14 @@
   template:
     src: roles/router/templates/systemd/10-aether-access.netdev
     dest: "{{ systemd_network_dir }}/10-aether-access.netdev"
-  when: inventory_hostname in groups['master_nodes']
+  when: inventory_hostname in groups['master_nodes'] and core.upf.multihop == false
   become: true
 
 - name: copy 20-aether-access.network to {{ systemd_network_dir }}/20-aether-access.network
   template:
     src: roles/router/templates/systemd/20-aether-access.network
     dest: "{{ systemd_network_dir }}/20-aether-access.network"
-  when: inventory_hostname in groups['master_nodes']
+  when: inventory_hostname in groups['master_nodes'] and core.upf.multihop == false
   become: true
 
 - name: copy 10-aether-core.netdev to {{ systemd_network_dir }}/10-aether-core.netdev
@@ -130,7 +130,7 @@
     in_interface: "{{ core.data_iface }}"
     out_interface: access
     jump: ACCEPT
-  when: inventory_hostname in groups['master_nodes']
+  when: inventory_hostname in groups['master_nodes'] and core.upf.multihop == false
   become: true
 
 - name: "add iptable rule: forward from access to {{ core.data_iface }}"
@@ -139,7 +139,7 @@
     in_interface: access
     out_interface: "{{ core.data_iface }}"
     jump: ACCEPT
-  when: inventory_hostname in groups['master_nodes']
+  when: inventory_hostname in groups['master_nodes'] and core.upf.multihop == false
   become: true
 
 - name: "add iptable rule: forward from {{ core.data_iface }} to core"

--- a/roles/router/tasks/uninstall.yml
+++ b/roles/router/tasks/uninstall.yml
@@ -13,7 +13,7 @@
     out_interface: access
     jump: ACCEPT
     state: absent
-  when: inventory_hostname in groups['master_nodes']
+  when: inventory_hostname in groups['master_nodes'] and core.upf.multihop == false
   become: true
   ignore_errors: yes
 
@@ -24,7 +24,7 @@
     out_interface: "{{ core.data_iface }}"
     jump: ACCEPT
     state: absent
-  when: inventory_hostname in groups['master_nodes']
+  when: inventory_hostname in groups['master_nodes'] and core.upf.multihop == false
   become: true
   ignore_errors: yes
 
@@ -93,7 +93,7 @@
   file:
     path: "{{ systemd_network_dir }}/20-aether-access.network"
     state: absent
-  when: inventory_hostname in groups['master_nodes']
+  when: inventory_hostname in groups['master_nodes'] and core.upf.multihop == false
   become: true
   ignore_errors: yes
 
@@ -101,7 +101,7 @@
   file:
     path: "{{ systemd_network_dir }}/10-aether-access.netdev"
     state: absent
-  when: inventory_hostname in groups['master_nodes']
+  when: inventory_hostname in groups['master_nodes'] and core.upf.multihop == false
   become: true
   ignore_errors: yes
 

--- a/roles/router/tasks/uninstall.yml
+++ b/roles/router/tasks/uninstall.yml
@@ -13,7 +13,7 @@
     out_interface: access
     jump: ACCEPT
     state: absent
-  when: inventory_hostname in groups['master_nodes'] and core.upf.multihop == false
+  when: inventory_hostname in groups['master_nodes'] and core.upf.non_isol_N3_nw == false
   become: true
   ignore_errors: yes
 
@@ -24,7 +24,7 @@
     out_interface: "{{ core.data_iface }}"
     jump: ACCEPT
     state: absent
-  when: inventory_hostname in groups['master_nodes'] and core.upf.multihop == false
+  when: inventory_hostname in groups['master_nodes'] and core.upf.non_isol_N3_nw == false
   become: true
   ignore_errors: yes
 
@@ -93,7 +93,7 @@
   file:
     path: "{{ systemd_network_dir }}/20-aether-access.network"
     state: absent
-  when: inventory_hostname in groups['master_nodes'] and core.upf.multihop == false
+  when: inventory_hostname in groups['master_nodes'] and core.upf.non_isol_N3_nw == false
   become: true
   ignore_errors: yes
 
@@ -101,7 +101,7 @@
   file:
     path: "{{ systemd_network_dir }}/10-aether-access.netdev"
     state: absent
-  when: inventory_hostname in groups['master_nodes'] and core.upf.multihop == false
+  when: inventory_hostname in groups['master_nodes'] and core.upf.non_isol_N3_nw == false
   become: true
   ignore_errors: yes
 

--- a/roles/router/tasks/uninstall.yml
+++ b/roles/router/tasks/uninstall.yml
@@ -13,7 +13,7 @@
     out_interface: access
     jump: ACCEPT
     state: absent
-  when: inventory_hostname in groups['master_nodes'] and core.upf.non_isol_N3_nw == false
+  when: inventory_hostname in groups['master_nodes'] and core.upf.multihop_gnb == false
   become: true
   ignore_errors: yes
 
@@ -24,7 +24,7 @@
     out_interface: "{{ core.data_iface }}"
     jump: ACCEPT
     state: absent
-  when: inventory_hostname in groups['master_nodes'] and core.upf.non_isol_N3_nw == false
+  when: inventory_hostname in groups['master_nodes'] and core.upf.multihop_gnb == false
   become: true
   ignore_errors: yes
 
@@ -93,7 +93,7 @@
   file:
     path: "{{ systemd_network_dir }}/20-aether-access.network"
     state: absent
-  when: inventory_hostname in groups['master_nodes'] and core.upf.non_isol_N3_nw == false
+  when: inventory_hostname in groups['master_nodes'] and core.upf.multihop_gnb == false
   become: true
   ignore_errors: yes
 
@@ -101,7 +101,7 @@
   file:
     path: "{{ systemd_network_dir }}/10-aether-access.netdev"
     state: absent
-  when: inventory_hostname in groups['master_nodes'] and core.upf.non_isol_N3_nw == false
+  when: inventory_hostname in groups['master_nodes'] and core.upf.multihop_gnb == false
   become: true
   ignore_errors: yes
 

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -13,10 +13,10 @@ core:
     access_subnet: "192.168.252.1/24"	# access subnet & gateway
     core_subnet: "192.168.250.1/24"	# core subnet & gateway
     mode: af_packet			# Options: af_packet or dpdk
-    non_isol_N3_nw: false               # when set to true, access subnet will be same as data_iface
+    multihop_gnb: false                 # when set to true, access subnet will be same as data_iface
     default_upf:
       ip:
-        access: "192.168.252.3"         # when non_isol_N3_nw set to true, make sure to assign IP from same subnet of data_iface
+        access: "192.168.252.3"         # when multihop_gnb set to true, make sure to assign IP from same subnet of data_iface
         core:   "192.168.250.3"
       ue_ip_pool: "172.250.0.0/16"
 

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -13,7 +13,7 @@ core:
     access_subnet: "192.168.252.1/24"	# access subnet & gateway
     core_subnet: "192.168.250.1/24"	# core subnet & gateway
     mode: af_packet			# Options: af_packet or dpdk
-    multihop: false
+    non_isol_N3_nw: false
     default_upf:
       ip:
         access: "192.168.252.3"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -13,6 +13,7 @@ core:
     access_subnet: "192.168.252.1/24"	# access subnet & gateway
     core_subnet: "192.168.250.1/24"	# core subnet & gateway
     mode: af_packet			# Options: af_packet or dpdk
+    multihop: false
     default_upf:
       ip:
         access: "192.168.252.3"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -13,10 +13,10 @@ core:
     access_subnet: "192.168.252.1/24"	# access subnet & gateway
     core_subnet: "192.168.250.1/24"	# core subnet & gateway
     mode: af_packet			# Options: af_packet or dpdk
-    non_isol_N3_nw: false
+    non_isol_N3_nw: false               # when set to true, access subnet will be same as data_iface
     default_upf:
       ip:
-        access: "192.168.252.3"
+        access: "192.168.252.3"         # when non_isol_N3_nw set to true, make sure to assign IP from same subnet of data_iface
         core:   "192.168.250.3"
       ue_ip_pool: "172.250.0.0/16"
 


### PR DESCRIPTION
By default onramp deploys UPF using isolated N3/N6 networks (192.168.252.x/192.168.250.x) respectively. But in most customer deployments the GNB's will be deployed on different subnets than the access subnets. In such cases the current deployment will not work. So we have to deploy the access n/w (N3) using the same subnet as host DATA_IFACE.

For example,
DATA_IFACE = 10.21.61.x
upf_access_interface = 10.21.61.y

GNB subnet: 10.202.1.x

In this case, the GNB's deployed on different subnets can directly access UPF N3 interface (10.21.61.y) using the existing networking. But if we use the isolated access network (like 192.168.252.x) then the traffic from GNB's cannot reach UPF.

This solution helps deploy GNB's in same subnet and different subnets. Please note that by default still onramp uses the isolated n/w deployment (current behavior). Our mechanism will be used only if user sets non_isol_N3_nw to true in vars/main.yml.    