### PR TITLE
Fix UEs IP addressing when IP address is assigned by SMF

### DIFF
--- a/roles/core/templates/radio-5g-values.yaml
+++ b/roles/core/templates/radio-5g-values.yaml
@@ -163,7 +163,7 @@ omec-sub-provision:
                 dnn: internet
                 dns-primary: "8.8.8.8"        # Value is sent to UE
                 mtu: 1460                     # Value is sent to UE when PDU Session Established
-                ue-ip-pool: "172.250.1.0/16"  # IP address pool for subscribers
+                ue-ip-pool: {{ core.upf.default_upf.ue_ip_pool }}  # IP address pool for subscribers
                 ue-dnn-qos:
                   dnn-mbr-downlink: 1000      # UE level downlink QoS (Maximum bit rate per UE)
                   dnn-mbr-uplink:   1000      # UE level uplink QoS (Maximum bit rate per UE)

--- a/roles/core/templates/sdcore-5g-sriov-values.yaml
+++ b/roles/core/templates/sdcore-5g-sriov-values.yaml
@@ -271,7 +271,7 @@ omec-sub-provision:
                 dnn: internet
                 dns-primary: "8.8.8.8"        # Value is sent to UE
                 mtu: 1460                     # Value is sent to UE when PDU Session Established
-                ue-ip-pool: "172.250.1.0/16"  # IP address pool for subscribers
+                ue-ip-pool: {{ core.upf.default_upf.ue_ip_pool }}  # IP address pool for subscribers
                 ue-dnn-qos:
                   dnn-mbr-downlink: 1000      # UE level downlink QoS (Maximum bit rate per UE)
                   dnn-mbr-uplink:   1000      # UE level uplink QoS (Maximum bit rate per UE)

--- a/roles/core/templates/sdcore-5g-values.yaml
+++ b/roles/core/templates/sdcore-5g-values.yaml
@@ -271,7 +271,7 @@ omec-sub-provision:
                 dnn: internet
                 dns-primary: "8.8.8.8"        # Value is sent to UE
                 mtu: 1460                     # Value is sent to UE when PDU Session Established
-                ue-ip-pool: "172.250.1.0/16"  # IP address pool for subscribers
+                ue-ip-pool: {{ core.upf.default_upf.ue_ip_pool }}  # IP address pool for subscribers
                 ue-dnn-qos:
                   dnn-mbr-downlink: 1000      # UE level downlink QoS (Maximum bit rate per UE)
                   dnn-mbr-uplink:   1000      # UE level uplink QoS (Maximum bit rate per UE)


### PR DESCRIPTION
Currently, the `ue_ip_pool` variable is used when the UPF is in charge of assigning IP addresses to UEs and in `20-aether-core.network` and `aether-ue-nat.service`. That is, a user can change the IP network for the UEs and the deployment is not going to work because by default the `smf` takes care of assigning IP address based on the configuration received from the `simapp`. However, the `simapp` has this UE IP network as a fixed value. This PR addresses this limitation such that the routes and NAT'ing are aligned to the IP range that was assigned to the UEs

The changes in this PR were tested using `gnbsim`

```
TASK [simulator : debug] ***********************************************************************************************
ok: [node1] => {
    "msg": [
        "Profile Name: profile2, Profile Type: pdusessest",
        "Ue's Passed: 5, Ue's Failed: 0",
        "Profile Status: PASS"
    ]
}
```

```
$ docker exec -ti gnbsim-1 cat gnbsim.log
...
...
2025-02-26T04:54:39.248Z        INFO    realue/realue.go:25     Handling: PDU-SESSION-ESTABLISHMENT-ACCEPT-EVENT       {"component": "GNBSIM", "category": "RealUe", "supi": "imsi-208930100007487"}
2025-02-26T04:54:39.248Z        INFO    context/realue.go:274   adding new PDU Session for PDU Sess ID: 10      {"component": "GNBSIM", "category": "RealUe", "supi": "imsi-208930100007487"}
2025-02-26T04:54:39.248Z        INFO    realue/handler.go:249   PDU Session ID: 10      {"component": "GNBSIM", "category": "RealUe", "supi": "imsi-208930100007487"}
2025-02-26T04:54:39.248Z        INFO    realue/handler.go:250   PDU Session Type: IPV4  {"component": "GNBSIM", "category": "RealUe", "supi": "imsi-208930100007487"}
2025-02-26T04:54:39.248Z        INFO    realue/handler.go:251   SSC Mode: 1     {"component": "GNBSIM", "category": "RealUe", "supi": "imsi-208930100007487"}
2025-02-26T04:54:39.248Z        INFO    realue/handler.go:252   PDU Address: 172.150.0.1        {"component": "GNBSIM", "category": "RealUe", "supi": "imsi-208930100007487"}
2025-02-26T04:54:39.248Z        INFO    stats/stats.go:227      Received Event: PDU_SESS_ACC_IN:  &{0001-01-01 00:00:00 +0000 UTC imsi-208930100007487 19 9}    {"component": "GNBSIM", "category": "Stats"}
2025-02-26T04:54:39.248Z        INFO    stats/stats.go:158      Find the UE  imsi-208930100007487       {"component": "GNBSIM", "category": "Stats"}
...
...
```


