### PR TITLE
Enhancement: Improved UPF routing and NAT handling

### DIFF
--- a/roles/router/tasks/install.yml
+++ b/roles/router/tasks/install.yml
@@ -68,6 +68,11 @@
   when: inventory_hostname in groups['master_nodes']
   become: true
 
+- name: Disable GRO flag on the {{ core.data_iface }} interface
+  shell: ethtool -K {{ core.data_iface }} gro off
+  when: inventory_hostname in groups['master_nodes']
+  become: true
+
 - name: find {{ core.data_iface }}'s netplan network directory
   shell: basename $(find /*/systemd/network -maxdepth 1 -not -type d -name '*{{ core.data_iface }}.network' -print)
   register: result

--- a/roles/router/tasks/install.yml
+++ b/roles/router/tasks/install.yml
@@ -1,5 +1,3 @@
----
-
 # TODO: running on master node for now (fix to run on multiple nodes)
 
 - set_fact:
@@ -70,11 +68,6 @@
   when: inventory_hostname in groups['master_nodes']
   become: true
 
-- name: Disable GRO flag on the {{ core.data_iface }} interface
-  shell: ethtool -K {{ core.data_iface }} gro off
-  when: inventory_hostname in groups['master_nodes']
-  become: true
-
 - name: find {{ core.data_iface }}'s netplan network directory
   shell: basename $(find /*/systemd/network -maxdepth 1 -not -type d -name '*{{ core.data_iface }}.network' -print)
   register: result
@@ -95,10 +88,12 @@
   when: inventory_hostname in groups['master_nodes']
   become: true
 
-- name: copy aether-ue-nat.service to {{ systemd_system_dir }}/aether-ue-nat.service
+# Use Jinja template for `aether-ue-nat.service`
+- name: Generate aether-ue-nat.service dynamically
   template:
-    src: roles/router/templates/systemd/aether-ue-nat.service
+    src: roles/router/templates/systemd/aether-ue-nat.service.j2
     dest: "{{ systemd_system_dir }}/aether-ue-nat.service"
+    mode: "0644"
   when: inventory_hostname in groups['master_nodes']
   become: true
 
@@ -122,7 +117,7 @@
   when: inventory_hostname in groups['master_nodes']
   become: true
 
-- name: restart systemd-networkd
+- name: Restart systemd-networkd
   systemd:
     name: systemd-networkd
     state: restarted

--- a/roles/router/templates/systemd/20-aether-core.network
+++ b/roles/router/templates/systemd/20-aether-core.network
@@ -8,6 +8,16 @@ Name=core
 IPForward=yes
 Address={{ core.upf.core_subnet }}
 
+# Default UPF Route
 [Route]
 Gateway={{ core.upf.default_upf.ip.core }}
 Destination={{ core.upf.default_upf.ue_ip_pool }}
+
+# Additional UPFs - Dynamically Generated Routes
+{% if core.upf.additional_upfs is defined and core.upf.additional_upfs %}
+{% for upf in core.upf.additional_upfs.values() %}
+[Route]
+Gateway={{ upf.ip.core }}
+Destination={{ upf.ue_ip_pool }}
+{% endfor %}
+{% endif %}

--- a/roles/router/templates/systemd/20-aether-core.network
+++ b/roles/router/templates/systemd/20-aether-core.network
@@ -8,16 +8,6 @@ Name=core
 IPForward=yes
 Address={{ core.upf.core_subnet }}
 
-# Default UPF Route
 [Route]
 Gateway={{ core.upf.default_upf.ip.core }}
 Destination={{ core.upf.default_upf.ue_ip_pool }}
-
-# Additional UPFs - Dynamically Generated Routes
-{% if core.upf.additional_upfs is defined and core.upf.additional_upfs %}
-{% for upf in core.upf.additional_upfs.values() %}
-[Route]
-Gateway={{ upf.ip.core }}
-Destination={{ upf.ue_ip_pool }}
-{% endfor %}
-{% endif %}

--- a/roles/router/templates/systemd/aether-ue-nat.service
+++ b/roles/router/templates/systemd/aether-ue-nat.service
@@ -1,9 +1,0 @@
-# Copyright 2022-present Open Networking Foundation
-# SPDX-License-Identifier: Apache-2.0
-
-[Service]
-Type=oneshot
-ExecStart=/bin/bash -c "sudo iptables -t nat -C POSTROUTING -s {{ core.upf.default_upf.ue_ip_pool }} -o {{ core.data_iface }} -j MASQUERADE || sudo iptables -t nat -A POSTROUTING -s {{ core.upf.default_upf.ue_ip_pool }} -o {{ core.data_iface }} -j MASQUERADE"
-
-[Install]
-WantedBy=sys-subsystem-net-devices-core.device

--- a/roles/router/templates/systemd/aether-ue-nat.service.j2
+++ b/roles/router/templates/systemd/aether-ue-nat.service.j2
@@ -10,15 +10,11 @@ Type=oneshot
 ExecStart=/bin/bash -c "\
     sudo iptables -t nat -C POSTROUTING -s {{ core.upf.default_upf.ue_ip_pool }} -o {{ core.data_iface }} -j MASQUERADE || \
     sudo iptables -t nat -A POSTROUTING -s {{ core.upf.default_upf.ue_ip_pool }} -o {{ core.data_iface }} -j MASQUERADE; \
-    {% if '1' in core.upf.additional_upfs %} \
-    sudo iptables -t nat -C POSTROUTING -s {{ core.upf.additional_upfs['1'].ue_ip_pool }} -o {{ core.data_iface }} -j MASQUERADE || \
-    sudo iptables -t nat -A POSTROUTING -s {{ core.upf.additional_upfs['1'].ue_ip_pool }} -o {{ core.data_iface }} -j MASQUERADE; \
-    {% endif %} \
-    {% if '2' in core.upf.additional_upfs %} \
-    sudo iptables -t nat -C POSTROUTING -s {{ core.upf.additional_upfs['2'].ue_ip_pool }} -o {{ core.data_iface }} -j MASQUERADE || \
-    sudo iptables -t nat -A POSTROUTING -s {{ core.upf.additional_upfs['2'].ue_ip_pool }} -o {{ core.data_iface }} -j MASQUERADE; \
-    {% endif %} \
+    {% for upf_key, upf_data in core.upf.additional_upfs.items() %} \
+    sudo iptables -t nat -C POSTROUTING -s {{ upf_data.ue_ip_pool }} -o {{ core.data_iface }} -j MASQUERADE || \
+    sudo iptables -t nat -A POSTROUTING -s {{ upf_data.ue_ip_pool }} -o {{ core.data_iface }} -j MASQUERADE; \
+    {% endfor %} \
 "
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=sys-subsystem-net-devices-core.device

--- a/roles/router/templates/systemd/aether-ue-nat.service.j2
+++ b/roles/router/templates/systemd/aether-ue-nat.service.j2
@@ -1,0 +1,24 @@
+# Copyright 2022-present Open Networking Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+[Unit]
+Description=Aether UE NAT Setup
+After=network.target
+
+[Service]
+Type=oneshot
+ExecStart=/bin/bash -c "\
+    sudo iptables -t nat -C POSTROUTING -s {{ core.upf.default_upf.ue_ip_pool }} -o {{ core.data_iface }} -j MASQUERADE || \
+    sudo iptables -t nat -A POSTROUTING -s {{ core.upf.default_upf.ue_ip_pool }} -o {{ core.data_iface }} -j MASQUERADE; \
+    {% if '1' in core.upf.additional_upfs %} \
+    sudo iptables -t nat -C POSTROUTING -s {{ core.upf.additional_upfs['1'].ue_ip_pool }} -o {{ core.data_iface }} -j MASQUERADE || \
+    sudo iptables -t nat -A POSTROUTING -s {{ core.upf.additional_upfs['1'].ue_ip_pool }} -o {{ core.data_iface }} -j MASQUERADE; \
+    {% endif %} \
+    {% if '2' in core.upf.additional_upfs %} \
+    sudo iptables -t nat -C POSTROUTING -s {{ core.upf.additional_upfs['2'].ue_ip_pool }} -o {{ core.data_iface }} -j MASQUERADE || \
+    sudo iptables -t nat -A POSTROUTING -s {{ core.upf.additional_upfs['2'].ue_ip_pool }} -o {{ core.data_iface }} -j MASQUERADE; \
+    {% endif %} \
+"
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/upf/tasks/install.yml
+++ b/roles/upf/tasks/install.yml
@@ -54,8 +54,10 @@
 
 - name: configure route for upf traffic on gnbsim node
   shell: |
+    ip route show | grep -q "{{ item.value.ue_ip_pool }} via {{ item.value.ip.core }}" || \
     ip route add {{ item.value.ue_ip_pool }} via {{ item.value.ip.core }}
   when: inventory_hostname in groups['master_nodes']
   with_dict: "{{ core.upf.additional_upfs}}"
   become: true
+
   # ignore_errors: yes

--- a/roles/upf/tasks/install.yml
+++ b/roles/upf/tasks/install.yml
@@ -59,5 +59,3 @@
   when: inventory_hostname in groups['master_nodes']
   with_dict: "{{ core.upf.additional_upfs}}"
   become: true
-
-  # ignore_errors: yes


### PR DESCRIPTION
Enhancement: Dynamic UPF Routing and NAT Handling

### Changes Made:
- Replaced static `aether-ue-nat.service` with `aether-ue-nat.service.j2` for dynamic NAT configuration..
- Updated `install.yaml` to generate the NAT service dynamically based on UPF configuration.
- Improved `20-aether-core.network` to dynamically add routes for additional UPFs.
- Modified the UPF module to check for existing routes before adding, preventing duplicate route errors.
- Ensured a consistent and streamlined route management approach between the core network and UPF installation.

### Why This Change?
- The original `aether-ue-nat.service` was **static**, meaning new UPFs required manual modifications.
- Using Jinja2 templating allows the NAT service to **automatically adapt** to new UPFs.
- Previously, additional UPFs required **route configuration**, which is being done in UPF role in install task  which near me should be part of router role.
- The new approach **automates UPF routing** in router role section   
- Ensures that UPF routes do not fail with `RTNETLINK answers: File exists` when adding new UPFs.

### Testing & Validation:
- Successfully deployed Aether 5GC with multiple UPFs without issues.
- Verified dynamic generation of NAT service using Jinja2.
- Ensured UPF routing was correctly applied without requiring manual intervention.
- No duplicate route errors occurred when adding multiple UPFs.

### Notes for Reviewers:
- Please verify if moving route handling to the router section aligns with project best practices.
- Open to feedback on improving the logic for route management.
