### PR TITLE
Remove warn logging level because it was properly fixed at the component level

### DIFF
--- a/roles/core/templates/radio-5g-values.yaml
+++ b/roles/core/templates/radio-5g-values.yaml
@@ -35,14 +35,13 @@ omec-control-plane:
     enabled: false
 
   config:
-    logger:
-      Util:
-        debugLevel: warn
-    #   # network function
+    # logger:
+    #   Util:
+    #     debugLevel: warn
     #   AMF:
-    #     debugLevel: trace
+    #     debugLevel: debug
     #   SMF:
-    #     debugLevel: trace
+    #     debugLevel: debug
 
     mongodb:
       name: aether

--- a/roles/core/templates/sdcore-5g-sriov-values.yaml
+++ b/roles/core/templates/sdcore-5g-sriov-values.yaml
@@ -35,14 +35,13 @@ omec-control-plane:
     enabled: false
 
   config:
-    logger:
-      Util:
-        debugLevel: warn
-    #   # network function
+    # logger:
+    #   Util:
+    #     debugLevel: warn
     #   AMF:
-    #     debugLevel: trace
+    #     debugLevel: debug
     #   SMF:
-    #     debugLevel: trace
+    #     debugLevel: debug
 
     mongodb:
       name: aether

--- a/roles/core/templates/sdcore-5g-values.yaml
+++ b/roles/core/templates/sdcore-5g-values.yaml
@@ -35,14 +35,13 @@ omec-control-plane:
     enabled: false
 
   config:
-    logger:
-      Util:
-        debugLevel: warn
-    #   # network function
+    # logger:
+    #   Util:
+    #     debugLevel: warn
     #   AMF:
-    #     debugLevel: trace
+    #     debugLevel: debug
     #   SMF:
-    #     debugLevel: trace
+    #     debugLevel: debug
 
     mongodb:
       name: aether


### PR DESCRIPTION
Also remove `trace` level, which does not exist in zap