### PR TITLE
Update device group name to comply with new validation done by the `webui`

### DIFF
--- a/roles/core/templates/radio-5g-values.yaml
+++ b/roles/core/templates/radio-5g-values.yaml
@@ -153,7 +153,7 @@ omec-sub-provision:
 
             # Configure Device Groups (ignored if provision-network-slice is disabled)
             device-groups:
-            - name:  "5g-user-group1"
+            - name:  "user-group1"
               imsis:
                 - "001010123456864"
                 - "001010123456865"
@@ -184,7 +184,7 @@ omec-sub-provision:
                 sd: "010203"
                 sst: 1
               site-device-group:
-              - "5g-user-group1"   # All UEs in this device-group are assigned to this slice
+              - "user-group1"   # All UEs in this device-group are assigned to this slice
               # Applicaiton filters control what each user can access.
               # Default, allow access to all applications
               application-filtering-rules:

--- a/roles/core/templates/sdcore-5g-sriov-values.yaml
+++ b/roles/core/templates/sdcore-5g-sriov-values.yaml
@@ -163,7 +163,7 @@ omec-sub-provision:
 
             # Configure Device Groups (ignored if provision-network-slice is disabled)
             device-groups:
-            - name:  "5g-gnbsim-user-group1"
+            - name:  "gnbsim-user-group1"
               imsis:
                 - "208930100007487"
                 - "208930100007488"
@@ -292,7 +292,7 @@ omec-sub-provision:
                 sd: "010203"
                 sst: 1
               site-device-group:
-              - "5g-gnbsim-user-group1"   # All UEs in this device-group are assigned to this slice
+              - "gnbsim-user-group1"   # All UEs in this device-group are assigned to this slice
               # Applicaiton filters control what each user can access.
               # Default, allow access to all applications
               application-filtering-rules:

--- a/roles/core/templates/sdcore-5g-values.yaml
+++ b/roles/core/templates/sdcore-5g-values.yaml
@@ -163,7 +163,7 @@ omec-sub-provision:
 
             # Configure Device Groups (ignored if provision-network-slice is disabled)
             device-groups:
-            - name:  "5g-gnbsim-user-group1"
+            - name:  "gnbsim-user-group1"
               imsis:
                 - "208930100007487"
                 - "208930100007488"
@@ -292,7 +292,7 @@ omec-sub-provision:
                 sd: "010203"
                 sst: 1
               site-device-group:
-              - "5g-gnbsim-user-group1"   # All UEs in this device-group are assigned to this slice
+              - "gnbsim-user-group1"   # All UEs in this device-group are assigned to this slice
               # Applicaiton filters control what each user can access.
               # Default, allow access to all applications
               application-filtering-rules:


### PR DESCRIPTION
This PRs updates the device-group name in the `simapp` to align with the new validation done by the `webui` (https://github.com/omec-project/webconsole/pull/314) such that a device-group-id cannot start with a number (`#`), `-` or `_`. This validation is aligned to what the ROC is already doing (https://github.com/opennetworkinglab/aether-amp/blob/master/roles/roc-load/templates/roc-5g-models.json#L77, https://github.com/opennetworkinglab/aether-amp/blob/master/roles/roc-load/templates/roc-5g-radio-models.json#L77 and https://github.com/opennetworkinglab/aether-amp/blob/master/roles/roc-load/templates/roc-5g-models-upf2.json#L77)
Without this change, data will not be loaded into the `webui` and all tests will fail due to missing configuration in the different NFs when `OnRamp` starts using the "newer" `webui` image, which has not been released as of yet