### PR TITLE
bugfix: 5gc uninstall deletes gnbsim macvlan config file

### DIFF
--- a/roles/router/tasks/uninstall.yml
+++ b/roles/router/tasks/uninstall.yml
@@ -65,10 +65,16 @@
   become: true
   ignore_errors: yes
 
-- name: delete {{ systemd_network_dir }}/{{ result.stdout }}.d
+- name: delete {{ systemd_network_dir }}/{{ result.stdout }}.d/macvlan.conf
   file:
-    path: "{{ systemd_network_dir }}/{{ result.stdout }}.d"
+    path: "{{ systemd_network_dir }}/{{ result.stdout }}.d/macvlan.conf"
     state: absent
+  when: inventory_hostname in groups['master_nodes']
+  become: true
+  ignore_errors: yes
+
+- name: delete {{ systemd_network_dir }}/{{ result.stdout }}.d if empty
+  shell: rmdir {{ systemd_network_dir }}/{{ result.stdout }}.d
   when: inventory_hostname in groups['master_nodes']
   become: true
   ignore_errors: yes


### PR DESCRIPTION
This bug fix is closely related to the issue described in [my other pull request](https://github.com/opennetworkinglab/aether-gnbsim/pull/20).

The issue addressed here is that `make 5gc-uninstall` deletes a macvlan configuration file directory that may contain a separate configuration file installed by `make gnbsim-install`.

In this fix, rather than immediately deleting the directory, I first remove the configuration file itself, and then delete the directory, but only if empty.

