### PR TITLE
bugfix: NAT rules are installed for core UPF, but not additional UPFs

### DIFF
--- a/roles/upf/tasks/install.yml
+++ b/roles/upf/tasks/install.yml
@@ -59,3 +59,11 @@
   with_dict: "{{ core.upf.additional_upfs}}"
   become: true
   # ignore_errors: yes
+
+- name: configure NAT for upf traffic
+  shell: |
+    sudo iptables -t nat -C POSTROUTING -s {{ item.value.ue_ip_pool }} -o {{ core.data_iface }} -j MASQUERADE || sudo iptables -t nat -A POSTROUTING -s {{ item.value.ue_ip_pool }} -o {{ core.data_iface }} -j MASQUERADE
+  when: inventory_hostname in groups['master_nodes']
+  with_dict: "{{ core.upf.additional_upfs}}"
+  become: true
+  # ignore_errors: yes


### PR DESCRIPTION
Currently, NAT rules are being installed for the first UPF, but not ones additionally added by `make 5gc-upf-install`. This PR fixes that by adding the proper `iptables` rules to the `5gc-upf-install` target.

To demonstrate the problem, you can follow the "Multiple UPFs" example in [Other Blueprints](https://docs.aetherproject.org/master/onramp/blueprints.html) within the Aether documentation. If you set the `defaultAs` [for the second UPF](https://github.com/opennetworkinglab/aether-gnbsim/blob/0f59a1289a578910cf41044f29299d64da0bb930/config/gnbsim-upf-2.yaml#L114) to the IP address of an external host (e.g., `8.8.8.8`), the UEs utilizing this UPF in the simulation will fail. You can confirm that there are missing NAT rules by executing
```
sudo iptables -t nat -L | grep MASQUERADE
```
and observing the IP range of the UEs assigned to the first UPF, but not the IP range of the UEs assigned to the second UPF. With this PR, each time you add a new UPF, you can do
```
make 5gc-upf-install
```
and observe that the appropriate NAT rules have been added.