### PR TITLE
Make UPF to assign IPs to UEs and update link to mongodb image

### DIFF
--- a/roles/core/templates/radio-5g-values.yaml
+++ b/roles/core/templates/radio-5g-values.yaml
@@ -30,6 +30,8 @@ omec-control-plane:
       enabled: false
     architecture: replicaset
     replicaCount: 2
+    image:
+      repository: bitnamilegacy/mongodb
 
   resources:
     enabled: false
@@ -267,7 +269,7 @@ omec-user-plane:
             dnn: "internet"              # Must match Slice dnn
             hostname: "upf"
             #http_port: "8080"
-            enable_ue_ip_alloc: false    # If true, UPF allocates address from following pool
+            enable_ue_ip_alloc: true    # If true, UPF allocates address from following pool
             ue_ip_pool: {{ core.upf.default_upf.ue_ip_pool }} # IP pool used UEs if enable_ue_ip_alloc=true
           slice_rate_limit_config:       # Slice-level rate limiting (also controlled by ROC)
             # Uplink

--- a/roles/core/templates/radio-5g-values.yaml
+++ b/roles/core/templates/radio-5g-values.yaml
@@ -55,7 +55,7 @@ omec-control-plane:
       enabled: true
 
     sctplb:
-      deploy: true # If enabled then deploy sctp pod
+      deploy: false # If enabled then deploy sctp pod
       ngapp:
         externalIp: {{ core.amf.ip }}
         port: 38412
@@ -76,6 +76,8 @@ omec-control-plane:
     # Most of the AMF config comes from Slice APIs but some of the config is
     # directly provided through Helm Charts
     amf:
+      ngapp:
+        externalIp: {{ core.amf.ip }}
       cfgFiles:
         amfcfg.yaml:
           configuration:

--- a/roles/core/templates/sdcore-5g-sriov-values.yaml
+++ b/roles/core/templates/sdcore-5g-sriov-values.yaml
@@ -30,6 +30,8 @@ omec-control-plane:
       enabled: false
     architecture: replicaset
     replicaCount: 2
+    image:
+      repository: bitnamilegacy/mongodb
 
   resources:
     enabled: false
@@ -383,7 +385,7 @@ omec-user-plane:
             dnn: "internet"              # Must match Slice dnn
             hostname: "upf"
             #http_port: "8080"
-            enable_ue_ip_alloc: false    # If true, UPF allocates address from following pool
+            enable_ue_ip_alloc: true    # If true, UPF allocates address from following pool
             ue_ip_pool: {{ core.upf.default_upf.ue_ip_pool }} # IP pool used UEs if enable_ue_ip_alloc=true
           slice_rate_limit_config:       # Slice-level rate limiting (also controlled by ROC)
             # Uplink

--- a/roles/core/templates/sdcore-5g-sriov-values.yaml
+++ b/roles/core/templates/sdcore-5g-sriov-values.yaml
@@ -55,7 +55,7 @@ omec-control-plane:
       enabled: true
 
     sctplb:
-      deploy: true # If enabled then deploy sctp pod
+      deploy: false # If enabled then deploy sctp pod
       ngapp:
         externalIp: {{ core.amf.ip }}
         port: 38412
@@ -76,6 +76,8 @@ omec-control-plane:
     # Most of the AMF config comes from Slice APIs but some of the config is
     # directly provided through Helm Charts
     amf:
+      ngapp:
+        externalIp: {{ core.amf.ip }}
       cfgFiles:
         amfcfg.yaml:
           configuration:

--- a/roles/core/templates/sdcore-5g-values.yaml
+++ b/roles/core/templates/sdcore-5g-values.yaml
@@ -30,6 +30,8 @@ omec-control-plane:
       enabled: false
     architecture: replicaset
     replicaCount: 2
+    image:
+      repository: bitnamilegacy/mongodb
 
   resources:
     enabled: false
@@ -375,7 +377,7 @@ omec-user-plane:
             dnn: "internet"              # Must match Slice dnn
             hostname: "upf"
             #http_port: "8080"
-            enable_ue_ip_alloc: false    # If true, UPF allocates address from following pool
+            enable_ue_ip_alloc: true    # If true, UPF allocates address from following pool
             ue_ip_pool: {{ core.upf.default_upf.ue_ip_pool }} # IP pool used UEs if enable_ue_ip_alloc=true
           slice_rate_limit_config:       # Slice-level rate limiting (also controlled by ROC)
             # Uplink

--- a/roles/core/templates/sdcore-5g-values.yaml
+++ b/roles/core/templates/sdcore-5g-values.yaml
@@ -55,7 +55,7 @@ omec-control-plane:
       enabled: true
 
     sctplb:
-      deploy: true # If enabled then deploy sctp pod
+      deploy: false # If enabled then deploy sctp pod
       ngapp:
         externalIp: {{ core.amf.ip }}
         port: 38412
@@ -76,6 +76,8 @@ omec-control-plane:
     # Most of the AMF config comes from Slice APIs but some of the config is
     # directly provided through Helm Charts
     amf:
+      ngapp:
+        externalIp: {{ core.amf.ip }}
       cfgFiles:
         amfcfg.yaml:
           configuration:


### PR DESCRIPTION
This PR includes 3 changes:
- For some reason the "old" `mongodb` images were moved by VMware to a different location. So, we point to the correct location to get the image(s)
- Make the UPF to assign IP addresses to UE by default
- Temporarily disabling `sctplb` due to its inability to handle n3iwf-ids