### PR TITLE
Chart version is ignored when using local charts. This PR makes that clear

### DIFF
--- a/roles/core/defaults/main.yml
+++ b/roles/core/defaults/main.yml
@@ -7,4 +7,4 @@ core:
   helm:
     local_charts: false
     chart_ref: aether/sd-core
-    chart_version: 2.0.0
+    chart_version: 3.1.3 # Ignored if using local charts (local_charts: true)

--- a/roles/core/tasks/install.yml
+++ b/roles/core/tasks/install.yml
@@ -82,7 +82,7 @@
         release_namespace: aether-5gc
         create_namespace: true
         chart_ref: "{{ core.helm.chart_ref if core.helm.local_charts == false else chart_ref_sd_core }}"
-        chart_version: "{{ core.helm.chart_version }}"
+        chart_version: "{{ core.helm.chart_version if core.helm.local_charts == false else omit }}"
         values_files:
           - /tmp/sdcore-5g-values.yaml
         wait: true

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -7,7 +7,7 @@ core:
   helm:
     local_charts: false
     chart_ref: aether/sd-core
-    chart_version: 2.0.0
+    chart_version: 3.1.3 # Ignored if using local charts (local_charts: true)
 
   upf:
     access_subnet: "192.168.252.1/24"	# access subnet & gateway


### PR DESCRIPTION
`Helm` read the chart version from the `Charts.yaml` file when using local charts. That is, it ignores the `chart_version` parameter when setting `local_charts: true`. So, this PR make this behavior explicit such that users do not get surprised by this