### PR TITLE
Avoid having to run helm dep up when using local charts and leave that to the developer

### DIFF
--- a/roles/core/tasks/install.yml
+++ b/roles/core/tasks/install.yml
@@ -57,10 +57,46 @@
     var: local_sd_core_chart_path
   when: inventory_hostname in groups['master_nodes'] and core.helm.local_charts
 
-- name: update aether 5gc-cp helm dependencies
-  shell: |
-    helm dep up /tmp/sdcore-helm-charts/5g-control-plane
+- name: read local 5gc-cp Chart.yaml
+  slurp:
+    src: /tmp/sdcore-helm-charts/5g-control-plane/Chart.yaml
+  register: core_cp_chart_yaml
   when: inventory_hostname in groups['master_nodes'] and core.helm.local_charts
+
+- name: derive local 5gc-cp chart dependency names
+  set_fact:
+    core_cp_dependency_names: >-
+      {{
+        ((core_cp_chart_yaml.content | b64decode | from_yaml).dependencies | default([]))
+        | map(attribute='name')
+        | list
+      }}
+  when: inventory_hostname in groups['master_nodes'] and core.helm.local_charts
+
+- name: check local 5gc-cp chart dependencies
+  find:
+    paths: /tmp/sdcore-helm-charts/5g-control-plane/charts
+    patterns: "{{ item }}-*"
+    recurse: false
+  loop: "{{ core_cp_dependency_names }}"
+  register: core_cp_chart_dependencies
+  when:
+    - inventory_hostname in groups['master_nodes']
+    - core.helm.local_charts
+    - core_cp_dependency_names | length > 0
+
+- name: require manual 5gc-cp helm dependency update when charts are missing
+  fail:
+    msg: >-
+      Missing 5g-control-plane chart dependencies under
+      /tmp/sdcore-helm-charts/5g-control-plane/charts. Run
+      'helm dep up {{ local_sd_core_chart_root }}/5g-control-plane' before
+      deploying with local SD-Core charts.
+      Missing: {{ core_cp_chart_dependencies.results | default([]) | selectattr('matched', 'equalto', 0) | map(attribute='item') | join(', ') }}.
+  when:
+    - inventory_hostname in groups['master_nodes']
+    - core.helm.local_charts
+    - (core_cp_chart_dependencies.results | default([]) | selectattr('matched', 'equalto', 0) | list | length) > 0
 
 - name: update aether 5gc helm dependencies
   shell: |

--- a/roles/core/tasks/install.yml
+++ b/roles/core/tasks/install.yml
@@ -73,6 +73,12 @@
       }}
   when: inventory_hostname in groups['master_nodes'] and core.helm.local_charts
 
+- name: check local 5gc-cp charts directory
+  stat:
+    path: /tmp/sdcore-helm-charts/5g-control-plane/charts
+  register: core_cp_charts_dir
+  when: inventory_hostname in groups['master_nodes'] and core.helm.local_charts
+
 - name: check local 5gc-cp chart dependencies
   find:
     paths: /tmp/sdcore-helm-charts/5g-control-plane/charts
@@ -83,6 +89,7 @@
   when:
     - inventory_hostname in groups['master_nodes']
     - core.helm.local_charts
+    - core_cp_charts_dir.stat.exists
     - core_cp_dependency_names | length > 0
 
 - name: require manual 5gc-cp helm dependency update when charts are missing
@@ -96,7 +103,7 @@
   when:
     - inventory_hostname in groups['master_nodes']
     - core.helm.local_charts
-    - (core_cp_chart_dependencies.results | default([]) | selectattr('matched', 'equalto', 0) | list | length) > 0
+    - not core_cp_charts_dir.stat.exists or (core_cp_chart_dependencies.results | default([]) | selectattr('matched', 'equalto', 0) | list | length) > 0
 
 - name: update aether 5gc helm dependencies
   shell: |


### PR DESCRIPTION
OnRamp/SD-Core (5gc-core-install) supports two options related to helm charts: `local_charts` and `GitHub registry` helm charts. Local helm charts are useful for developers to enable/test new capabilities in cases where a feature also needs changes in Helm Charts.

The SD-Core (5G-CP) uses `mongodb` and `kafka` as sub-charts. So, Onramp/Ansible runs 2 `helm dep up` (one inside 5g-control-plane` and one inside the umbrella chart).

The objective of this PR is to avoid the 1st `helm dep up` and leave that to the developer (added a proper message in the PR) and also will it in the documentation (aether-docs). This is because some corner cases we have recently found where no internet is available (e.g., demos, etc.) and the images are already local in the K8s cluster but because of the Helm Charts dependency, helm tries to pull the sub-charts from the internet and the deployment fails