### PR TITLE
UPF needs to have enabled resources when deploying it in DPDK mode

### DIFF
--- a/roles/core/templates/sdcore-5g-sriov-values.yaml
+++ b/roles/core/templates/sdcore-5g-sriov-values.yaml
@@ -448,7 +448,7 @@ omec-user-plane:
   nodeSelectors:
     enabled: true
   resources:
-    enabled: false
+    enabled: true
   # images:
   #   repository: ""
   #   tags:


### PR DESCRIPTION
For the UPF to get deployed in DPDK mode, the `resources` parameter needs to be enabled